### PR TITLE
Make it possible to run the ANTLR4 tool offline

### DIFF
--- a/antlr4_tool_runner.py
+++ b/antlr4_tool_runner.py
@@ -10,6 +10,16 @@ import json
 import jdk  # requires install-jdk package
 
 
+mvn_repo: str
+homedir: Path
+
+
+def initialize_paths():
+    global mvn_repo, homedir
+    homedir = Path.home()
+    mvn_repo = os.path.join(homedir, '.m2', 'repository', 'org', 'antlr', 'antlr4')
+
+
 def latest_version():
     with urlopen(f"https://search.maven.org/solrsearch/select?q=a:antlr4-master+g:org.antlr") as response:
         s = response.read().decode("UTF-8")
@@ -77,10 +87,6 @@ def install_jre(java_version='11'):
 
 
 def install_jre_and_antlr(version):
-    global mvn_repo, homedir
-    homedir = Path.home()
-    mvn_repo = os.path.join(homedir, '.m2', 'repository', 'org', 'antlr', 'antlr4')
-
     jar = antlr4_jar(version)
     java = which("java")
     if java is None:
@@ -108,6 +114,7 @@ def get_version_arg(args):
 
 def tool():
     """Entry point to run antlr4 tool itself"""
+    initialize_paths()
     args = sys.argv[1:]
     args, version = get_version_arg(args)
     jar, java = install_jre_and_antlr(version)
@@ -123,6 +130,7 @@ def tool():
 
 def interp():
     """Entry point to run antlr4 profiling using grammar and input file"""
+    initialize_paths()
     args = sys.argv[1:]
     args, version = get_version_arg(args)
     jar, java = install_jre_and_antlr(version)


### PR DESCRIPTION
Previously, if the tool was run while the computer was offline, it would not work even if any version of ANTLR was already installed previously. This was because the tool always had to retrieve the latest version from maven APIs and errored out if that didn't work. Now, we instead try to look for any already-installed ANTLR4 and use the latest one. This might provide the user with an out-of-date version of ANTLR4, which is why we make sure to always report the version to them. However, I consider this to be better than preventing the user from using the tool altogether offline.