### PR TITLE
Support overriding ANTLR version from environment variable, and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,7 @@ ANTLR Parser Generator  Version 4.11.1
 ...
 ```
 
-## Running ANTLR tool on grammars
-
-```bash
-$ antlr4
-ANTLR Parser Generator  Version 4.10.1
- -o ___              specify output directory where all output is generated
- -lib ___            specify location of grammars, tokens files
-...
-```
-
-The only extra argument that the `antlr4` command provides over the actual ANTLR tool commands is `-v`, which has to be the first argument:
+To override the version of ANTLR jar used, you can pass a `-v <version>` argument or set `ANTLR4_TOOLS_ANTLR_VERSION` environment variable:
 
 ```bash
 $ antlr4 -v 4.9.3
@@ -59,7 +49,16 @@ ANTLR Parser Generator  Version 4.9.3
  -o ___              specify output directory where all output is generated
  -lib ___            specify location of grammars, tokens files
 ...
+$ ANTLR4_TOOLS_ANTLR_VERSION=4.10.1 antlr4
+ANTLR Parser Generator  Version 4.10.1
+ -o ___              specify output directory where all output is generated
+ -lib ___            specify location of grammars, tokens files
+...
 ```
+
+## Running ANTLR tool on grammars
+
+The `antlr4` command forwards all arguments (besides `-v` mentioned above) to the actual ANTLR tool command:
 
 ```bash
 $ antlr4 JSON.g4 
@@ -72,12 +71,12 @@ JSONLexer.py     JSONListener.py  JSONParser.py    JSONVisitor.py
 
 ## Parsing using interpreter
 
-The `antlr4-parse` command requires ANTLR 4.11 and above (but any version of ANTLR works for the plain `antlr4` command).  The only extra argument that the `antlr4-parse` command provides over the actual ANTLR `org.antlr.v4.gui.Interpreter` "command" is `-v`, which has to be the first argument.  (Note: `^D` means control-D and indicates "end of input" on Unix but use `^Z` on Windows.)
+The `antlr4-parse` command requires ANTLR 4.11 and above (but any version of ANTLR works for the plain `antlr4` command).  It accepts the same `-v` argument or environment variable to override the ANTLR jar version used.  (Note: `^D` means control-D and indicates "end of input" on Unix but use `^Z` on Windows.)
 
 Let's play with a simple grammar:
 
 ```
-grammar Expr;		
+grammar Expr;
 prog:	expr EOF ;
 expr:	expr ('*'|'/') expr
     |	expr ('+'|'-') expr

--- a/antlr4_tool_runner.py
+++ b/antlr4_tool_runner.py
@@ -127,35 +127,23 @@ def process_args():
     )
 
 
-def tool():
-    """Entry point to run antlr4 tool itself"""
+def run_cli(entrypoint):
     initialize_paths()
     args, version = process_args()
     jar, java = install_jre_and_antlr(version)
 
-    p = subprocess.Popen([java, '-cp', jar, 'org.antlr.v4.Tool']+args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-    out = out.decode("UTF-8")
-    err = err.decode("UTF-8")
+    cp = subprocess.run([java, '-cp', jar, entrypoint]+args)
+    sys.exit(cp.returncode)
 
-    if err: print(err, end='')
-    if out: print(out, end='')
+
+def tool():
+    """Entry point to run antlr4 tool itself"""
+    run_cli('org.antlr.v4.Tool')
 
 
 def interp():
     """Entry point to run antlr4 profiling using grammar and input file"""
-    initialize_paths()
-    args = sys.argv[1:]
-    args, version = process_args(args)
-    jar, java = install_jre_and_antlr(version)
-
-    p = subprocess.Popen([java, '-cp', jar, 'org.antlr.v4.gui.Interpreter']+args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-    out = out.decode("UTF-8")
-    err = err.decode("UTF-8")
-
-    if err: print(err, end='')
-    if out: print(out, end='')
+    run_cli('org.antlr.v4.gui.Interpreter')
 
 
 if __name__ == '__main__':

--- a/antlr4_tool_runner.py
+++ b/antlr4_tool_runner.py
@@ -58,7 +58,6 @@ def download_antlr4(jar, version):
             s = response.read()
     except error.URLError as e:
         print(f"Could not find antlr4-{version}-complete.jar at maven.org")
-        ResponseData = e.read().decode("utf8", 'ignore')
 
     if s is None:
         return None

--- a/antlr4_tool_runner.py
+++ b/antlr4_tool_runner.py
@@ -23,7 +23,7 @@ def initialize_paths():
 
 def latest_version():
     try:
-        with urlopen(f"https://search.maven.org/solrsearch/select?q=a:antlr4-master+g:org.antlr") as response:
+        with urlopen(f"https://search.maven.org/solrsearch/select?q=a:antlr4-master+g:org.antlr", timeout=10) as response:
             s = response.read().decode("UTF-8")
             searchResult = json.loads(s)['response']
             # searchResult = s.json()['response']
@@ -52,7 +52,7 @@ def antlr4_jar(version):
 def download_antlr4(jar, version):
     s = None
     try:
-        with urlopen(f"https://repo1.maven.org/maven2/org/antlr/antlr4/{version}/antlr4-{version}-complete.jar") as response:
+        with urlopen(f"https://repo1.maven.org/maven2/org/antlr/antlr4/{version}/antlr4-{version}-complete.jar", timeout=60) as response:
             print(f"Downloading antlr4-{version}-complete.jar")
             os.makedirs(os.path.join(mvn_repo, version), exist_ok=True)
             s = response.read()


### PR DESCRIPTION
While trying to use this tool for a project, I found a few shortcomings that I wanted to improve

I tried limiting changes to a minimum, but I'd be happy to do some followup code cleanup, making the code look more idiomatic Python and so on, but only if you are receptive for it.

Long story short, here are the changes and my reasoning for them:

* Yesterday, maven package search was unavailable for a while, which made the whole program stuck waiting for an HTTP response for eternity. I Added some sanity timeout values, so it aborts after a reasonable time
* While trying to work around the issue, I've read about the `-v` argument and was happy that it bypasses the search for latest version, and in general found it a good idea to be able to pin down the version of antlr used.  
  When used from scripts, using an environment variable is more convenient, as the `-v` argument doesn't need to be repeated in all the places the commands are used.  
  Making the `-v` working at all argument position was just a happy accident.
* As I read through the code, found that exit code was not propagated and also found that stdout/err was needlessly captured  