### PR TITLE
tool_runner: avoid crash when urlopen raise HTTPError

### DIFF
--- a/antlr4_tool_runner.py
+++ b/antlr4_tool_runner.py
@@ -31,7 +31,7 @@ def latest_version():
             # print(json.dump(searchResult))
             latest = antlr_info['latestVersion']
             return latest
-    except error.URLError as e:
+    except (error.URLError, error.HTTPError) as e:
         print("Could not get latest version number, attempting to fall back to latest downloaded version...")
         version_dirs = list(filter(lambda directory: re.match(r"[0-9]+\.[0-9]+\.[0-9]+", directory), os.listdir(mvn_repo)))
         version_dirs.sort(reverse=True)
@@ -56,7 +56,7 @@ def download_antlr4(jar, version):
             print(f"Downloading antlr4-{version}-complete.jar")
             os.makedirs(os.path.join(mvn_repo, version), exist_ok=True)
             s = response.read()
-    except error.URLError as e:
+    except (error.URLError, error.HTTPError) as e:
         print(f"Could not find antlr4-{version}-complete.jar at maven.org")
         ResponseData = e.read().decode("utf8", 'ignore')
 


### PR DESCRIPTION
I meet following error when using antlr4-tools. This patch wants to avoid crash when checking version failed due to network usse.

```
Traceback (most recent call last):
  File "/opt/homebrew/bin/antlr4", line 8, in <module>
    sys.exit(tool())
             ^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/antlr4_tool_runner.py", line 112, in tool
    args, version = get_version_arg(args)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/antlr4_tool_runner.py", line 105, in get_version_arg
    version = latest_version()
              ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/antlr4_tool_runner.py", line 14, in latest_version
    with urlopen(f"https://search.maven.org/solrsearch/select?q=a:antlr4-master+g:org.antlr") as response:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 525, in open
    response = meth(req, response)
               ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 634, in http_response
    response = self.parent.error(
               ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 563, in error
    return self._call_chain(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 496, in _call_chain
    result = func(*args)
             ^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 504: Gateway Time-out
ninja: build stopped: subcommand failed.

```