### PR TITLE
Adjust jar package search url to use `search.maven.org`

### DIFF
--- a/antlr4_tool_runner.py
+++ b/antlr4_tool_runner.py
@@ -23,7 +23,7 @@ def initialize_paths():
 
 def latest_version():
     try:
-        with urlopen("https://central.sonatype.com/solrsearch/select?q=a:antlr4-master+g:org.antlr",
+        with urlopen("https://search.maven.org/solrsearch/select?q=a:antlr4-master+g:org.antlr",
                      timeout=10) as response:
             s = response.read().decode("UTF-8")
             searchResult = json.loads(s)['response']

--- a/antlr4_tool_runner.py
+++ b/antlr4_tool_runner.py
@@ -23,7 +23,7 @@ def initialize_paths():
 
 def latest_version():
     try:
-        with urlopen("https://search.maven.org/solrsearch/select?q=a:antlr4-master+g:org.antlr",
+        with urlopen("https://search.maven.org/solrsearch/select?q=a:antlr4-master+AND+g:org.antlr&wt=json",
                      timeout=10) as response:
             s = response.read().decode("UTF-8")
             searchResult = json.loads(s)['response']


### PR DESCRIPTION
## About
The intention is to prevent being flagged or rejected as a bot by `central.sonatype.com` when invoked on CI systems like GitHub Actions (GHA).

## Preview
```shell
uv pip install --upgrade 'antlr4-tools @ git+https://github.com/crate-workbench/antlr4-tools@search.maven.org'
```

## References
- Problem: GH-22
- Problem: https://github.com/crate/cratedb-sqlparse/issues/170
- Validation: https://github.com/crate/cratedb-sqlparse/pull/247